### PR TITLE
Add Pipfile to more easily install dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"jinja2" = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"


### PR DESCRIPTION
A Pipfile is a replacement for requirements.txt, installable via `pipenv sync`.