### PR TITLE
Support revocation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const irma = require('@privacybydesign/irma-frontend');
 
-const LANG = 'en'; // TODO
+const LANG = document.getElementsByTagName("html")[0].getAttribute("lang");
 const MAX_SEARCH = 8; // max number of search results in the results dropdown
 const IRMA_SERVER = 'https://demo.privacybydesign.foundation/backend';
 

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -73,7 +73,7 @@
 		</div>
 		{% endfor %}
 		<div id="issue-alert" class="alert alert-success" style="display: none;">
-			Issuance succesful. The <a href="https://irma.app/docs/revocation/#revocation">revocation key</a>
+			Issuance successful. The <a href="https://irma.app/docs/revocation/#revocation">revocation key</a>
 			of the credential is: <strong><code id="revocation-key" style="color: unset;"></code></strong>
 		</div>
 		<button type="submit" class="btn btn-primary">Issue</button>

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -25,6 +25,13 @@
 		<dd>No. Multiple instances of this credential will be accepted by the IRMA app.</dd>
 		{% endif %}
 
+		<dt>Revocation?</dt>
+		{% if credential.revocation %}
+		<dd>Yes. Instances of this credential can be revoked by the issuer.</dd>
+		{% else %}
+		<dd>No. Instances of this credential cannot be revoked by the issuer.</dd>
+		{% endif %}
+
 		<dt>XML source</dt>
 		<dd>
 			<ul>
@@ -37,7 +44,10 @@
 	<h3>Attributes</h3>
 	<p>This credential contains the following attributes:</p>
 	{% for attribute in credential.attributes %}
-	<h4 class="attribute name" id="{{ attribute.identifier }}">{{ attribute.name[LANG] }}</h4>
+	<h4 class="attribute name" id="{{ attribute.identifier }}">
+		{{ attribute.name[LANG] }}
+		{% if attribute.optional %}(optional){% endif %}
+	</h4>
 	<dl class="items">
 		<dt>Identifier</dt>
 		<dd class="identifier">{{ attribute.identifier }}</dd>
@@ -53,7 +63,11 @@
 	<form class="diy-credential" data-credential="{{ credential.identifier }}" onsubmit="return false;">
 		{% for attribute in credential.attributes %}
 		<div class="form-group">
-			<label for="selfissue-{{ attribute.id }}">{{ attribute.description[LANG] }} (<span class="identifier">{{ attribute.id }}</span>)</label>
+			<label for="selfissue-{{ attribute.id }}">
+				{{ attribute.description[LANG] }}
+				(<span class="identifier">{{ attribute.id }}</span>)
+				{% if attribute.optional %}(optional){% endif %}
+			</label>
 			<input type="text" class="form-control" id="selfissue-{{ attribute.id }}" data-attribute="{{ attribute.id }}">
 		</div>
 		{% endfor %}

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -18,9 +18,6 @@
 		<dt>Description</dt>
 		<dd>{{ credential.description[LANG] }}</dd>
 
-		<dt>Short name</dt>
-		<dd>{{ credential.shortName[LANG] }}</dd>
-
 		<dt>Singleton?</dt>
 		{% if credential.shouldBeSingleton %}
 		<dd>Yes. The IRMA app will only allow one instance of this credential. A newly issued credential will overwrite an existing credential of the same type.</dd>

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -71,6 +71,10 @@
 			<input type="text" class="form-control" id="selfissue-{{ attribute.id }}" data-attribute="{{ attribute.id }}">
 		</div>
 		{% endfor %}
+		<div id="issue-alert" class="alert alert-success" style="display: none;">
+			Issuance succesful. The <a href="https://irma.app/docs/revocation/#revocation">revocation key</a>
+			of the credential is: <strong><code id="revocation-key" style="color: unset;"></code></strong>
+		</div>
 		<button type="submit" class="btn btn-primary">Issue</button>
 	</form>
 	{% endif %}

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -47,6 +47,7 @@
 	<h4 class="attribute name" id="{{ attribute.identifier }}">
 		{{ attribute.name[LANG] }}
 		{% if attribute.optional %}(optional){% endif %}
+		{% if attribute.randomblind %}(randomblind){% endif %}
 	</h4>
 	<dl class="items">
 		<dt>Identifier</dt>
@@ -61,7 +62,7 @@
 	<p>With this form, you can issue demo attributes of this credential for testing and demonstration
 	purposes. (Note that only demo attributes can be issued this way.)</p>
 	<form class="diy-credential" data-credential="{{ credential.identifier }}" onsubmit="return false;">
-		{% for attribute in credential.attributes %}
+		{% for attribute in credential.attributes if not attribute.randomblind %}
 		<div class="form-group">
 			<label for="selfissue-{{ attribute.id }}">
 				{{ attribute.description[LANG] }}

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -23,15 +23,23 @@
 			<p>A scheme describes all issuers, all credentials, as well as attributes it contains. (Additionally, it contains the IRMA public keys of the issuers against which their attributes can be verified.) An example of a scheme is the <a href="https://github.com/privacybydesign/pbdf-schememanager">Privacy by Design Foundation scheme</a>.</p>
 		</dd>
 		<dt id="disclosure">Disclosure process</dt>
-			<p>You can read more about the disclosure process in the <a href="https://credentials.github.io/protocols/irma-protocol/">protocol description</a>.</p>
+			<p>You can read more about the disclosure process in the <a href="https://irma.app/docs/overview/">technical documentation</a>.</p>
 		<dt id="identifier">Identifier<dt>
 		<dd>
-			<p>An identifier uniquely identifies an attribute type, credential type, issuer, or scheme. Examples are <code>pbdf.pbdf.ageLimits.over18</code> which is the <a href="pbdf.pbdf.ageLimits.html#pbdf.pbdf.ageLimits.over18">Over 18</a> attribute, <code>pbdf.pbdf.big</code> which is the <a href="pbdf.pbdf.big.html">BIG registration</a> credential, or <code>pbdf.pbdf</code> which is the <a href="pbdf.pbdf.html">Privacy by Design Foundation</a> issuer.</p>
+			<p>An identifier uniquely identifies an attribute type, credential type, issuer, or scheme. Examples are <code>pbdf.gemeente.personalData.over18</code> which is the <a href="pbdf.gemeente.personalData.html#pbdf.gemeente.personalData.over18">Over 18</a> attribute, <code>pbdf.sidn-pbdf.email</code> which is the <a href="pbdf.sidn-pbdf.email.html">email</a> credential, or <code>pbdf.pbdf</code> which is the <a href="pbdf.pbdf.html">Privacy by Design Foundation</a> issuer.</p>
+		</dd>
+		<dt id="singleton">Singleton credentials</dt>
+		<dd>
+			<p>Of some credentials, the IRMA app is allowed to possess at most one instance of it simultaneously. This is enabled for credentials for which it does not make sense for one person to have more than one instance. An example is the <a href="pbdf.gemeente.personalData.html"><code>pbdf.gemeente.personalData</code></a> credential: a person can have only one name. A non-example is the <a href="pbdf.sidn-pbdf.email.html"><code>pbdf.sidn-pbdf.email</code></a> credential: a person can have many email addresses.</p>
+		</dd>
+		<dt id="revocation">Revocation</dt>
+		<dd>
+			<p>For some credentials, the issuer may have the ability to revoke them after issuance if it finds that the credential contents are no longer correct or appropriated. For example address attributes after you moved, or driver's license attributes corresponding to a driver's license which has been revoked. For more details, see the <a href="https://irma.app/docs/revocation/">technical documentation</a> on revocation.</p>
 		</dd>
 		<dt id="xml-source">XML source</dt>
 		<dd>
 			<p>Each page of this index is an automatically generated human-readable view on an XML file within a scheme. Each page include a link to the XML file from which it was generated.</p>
 		</dd>
 	</dl>
-	<p>For a more comprehensive introduction of these entities and their role in the IRMA infrastructure, see the <a href="https://credentials.github.io/docs/irma.html">technical documentation</a>.</p>
+	<p>For a more comprehensive introduction of these entities and their role in the IRMA infrastructure, see the <a href="https://irma.app/docs">technical documentation</a>.</p>
 {% endblock main %}

--- a/templates/issuer.html
+++ b/templates/issuer.html
@@ -13,9 +13,6 @@
 		<dt>Issuer <a href="glossary.html#identifier">identifier</a>
 		<dd class="identifier">{{ issuer.identifier }}</dd>
 
-		<dt>Short name</dt>
-		<dd>{{ issuer.shortName[LANG] }}</dd>
-
 		<dt>Contact</dt>
 		<dd><a href="mailto:{{ issuer.contactEmail }}">{{ issuer.contactEmail }}</a></dd>
 

--- a/update.py
+++ b/update.py
@@ -48,6 +48,7 @@ def readAttribute(xml, credential):
         'id':          xml.getAttribute('id'),
         'optional':    len(xml.getAttribute('optional')) > 0,
         'revocation':  len(xml.getAttribute('revocation')) > 0,
+        'randomblind': len(xml.getAttribute('randomblind')) > 0,
         'name':        translated(name[0]) if len(name) > 0 else None,
         'description': translated(desc[0]) if len(desc) > 0 else None,
     }

--- a/update.py
+++ b/update.py
@@ -42,10 +42,14 @@ def translated(element):
     return strings
 
 def readAttribute(xml, credential):
+    name = xml.getElementsByTagName('Name')
+    desc = xml.getElementsByTagName('Description')
     attribute = {
         'id':          xml.getAttribute('id'),
-        'name':        translated(xml.getElementsByTagName('Name')[0]),
-        'description': translated(xml.getElementsByTagName('Description')[0]),
+        'optional':    len(xml.getAttribute('optional')) > 0,
+        'revocation':  len(xml.getAttribute('revocation')) > 0,
+        'name':        translated(name[0]) if len(name) > 0 else None,
+        'description': translated(desc[0]) if len(desc) > 0 else None,
     }
     attribute['identifier'] = '%s.%s' % (credential['identifier'], attribute['id'])
     return attribute
@@ -59,6 +63,7 @@ def readCredential(path):
         'name':              translated(xml.getElementsByTagName('Name')[0]),
         'shortName':         translated(xml.getElementsByTagName('ShortName')[0]),
         'description':       translated(xml.getElementsByTagName('Description')[0]),
+        'revocation':        xml.getElementsByTagName('RevocationServers').length > 0,
         'logo':              path + '/logo.png',
         'shouldBeSingleton': False,
         'attributes':        [],
@@ -73,7 +78,10 @@ def readCredential(path):
     for attribute in xml.getElementsByTagName('Attributes')[0].childNodes:
         if attribute.nodeType != attribute.ELEMENT_NODE:
             continue
-        credential['attributes'].append(readAttribute(attribute, credential))
+        credentialAttr = readAttribute(attribute, credential)
+        if credentialAttr['revocation']:
+            continue
+        credential['attributes'].append(credentialAttr)
 
     return credential
 


### PR DESCRIPTION
This makes the attribute index aware of revocation, and enables issuance of revocation-enabled demo credential types. Additionally several small features are added:

* Show randomblind indicators to applicable attributes, and don't show issuance input field for randomblind attributes
* Show optional indicators to applicable attributes
* Remove short names from issuer and credential pages as they are nowhere used
* Make search feature aware of translated text
* Update and expand glossary