### PR TITLE
Add issuer deprecation notice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir Jinja2 requests && \
     python3 -u generate-index.py 
 
 # --- Stage 3: Final nginx stage
-FROM nginx:stable
+FROM nginx:stable-alpine
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "80:80"
+      - "8080:80"
     environment:
       - NODE_OPTIONS=--openssl-legacy-provider
     restart: unless-stopped

--- a/generate-index.py
+++ b/generate-index.py
@@ -94,12 +94,14 @@ def readCredential(path):
 
 def readIssuer(path):
     xml = minidom.parse(path + '/description.xml')
+    deprecated = xml.getElementsByTagName('DeprecatedSince')
     issuer = {
         'id':           getText(xml.getElementsByTagName('ID')[0]),
         'schememgr':    getText(xml.getElementsByTagName('SchemeManager')[0]),
         'shortName':    translated(xml.getElementsByTagName('ShortName')[0]),
         'name':         translated(xml.getElementsByTagName('Name')[0]),
         'contactEmail': getText(xml.getElementsByTagName('ContactEMail')[0]),
+        'deprecated':   getTime(deprecated[0]) if len(deprecated) > 0 else None,
         'logo':         path + '/logo.png',
         'credentials':  {},
     }
@@ -116,7 +118,6 @@ def get_issuer_name(issuer_tuple):
 
 def readSchemeManager(path):
     schememgr = {}
-
     xml = minidom.parse(path + '/description.xml')
     schememgr = {
         'id':                getText(xml.getElementsByTagName('Id')[0]),
@@ -169,8 +170,6 @@ def generateHTML(index, out, lang):
            LANG=lang,
            identifier='glossary')
 
-    
-
     organized_data = []
     for schememgr in index:
         scheme_data = {
@@ -218,8 +217,6 @@ def generateHTML(index, out, lang):
                        LANG=lang,
                        identifier=credential['identifier'])
 
-                    
-                       
     render(out + '/credential-navigator.html', 'credential-navigator.html',
         index=index,
         organized_data=organized_data,
@@ -231,17 +228,13 @@ if __name__ == '__main__':
     if os.path.exists(config_file):
         with open(config_file) as f:
             schememanagers = json.load(f)
-    try:
-        index = []
-        for info in schememanagers:
-            index.append(readSchemeManager(info['PATH']))
-        
-        with open('index.json', 'w') as json_file:
-            json.dump(index, json_file)
-        print("JSON file generated: index.json")
+    index = []
+    for info in schememanagers:
+        index.append(readSchemeManager(info['PATH']))
+    
+    with open('index.json', 'w') as json_file:
+        json.dump(index, json_file)
+    print("JSON file generated: index.json")
 
-        generateHTML(index, 'en', 'en')
-        generateHTML(index, 'nl', 'nl')
-
-    except Exception as e:
-        print(f"An error occurred: {e}")
+    generateHTML(index, 'en', 'en')
+    generateHTML(index, 'nl', 'nl')

--- a/templates/issuer.html
+++ b/templates/issuer.html
@@ -6,6 +6,13 @@
 	<img class="float-right" width="100" src="{{ assets }}/{{ issuer.logo }}"/>
 	<h2>{{ issuer.name[LANG] }}</h2>
 	<p class="subtitle">Issuer</p>
+
+	{% if issuer.deprecated %}
+	<div class="alert alert-warning warning-test"><strong>This issuer is deprecated since {{ issuer.deprecated }}</strong>.<br/>
+		Users cannot obtain credentials from this issuer anymore, although they might still possess credentials issued before this date.
+		When using credentials from this issuer, please provide users with a non-deprecated alternative.</div>
+	{% endif %}
+
 	{% if schememgr.test %}
 	<div class="alert alert-warning warning-test"><strong>This is a testing issuer.</strong> Its IRMA private key is public, so anyone can issue credentials with this issuer. Use it for testing and demo purposes only.</div>
 	{% endif %}


### PR DESCRIPTION
This pull request includes several changes to improve the handling of deprecated issuers, update configurations, and clean up the codebase. The most important changes include adding a deprecation warning for issuers, updating Docker configurations, and removing unnecessary code.

### Handling of deprecated issuers:
* [`generate-index.py`](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182R97-R104): Added logic to read and store the `DeprecatedSince` field from the issuer XML file.
* [`templates/issuer.html`](diffhunk://#diff-c0e264fdcc16d1bf7c3fd94017f5f441ea2b6405a4321d1a8ef185797df0ce6dR9-R15): Added a deprecation warning message to be displayed if the issuer is deprecated.

### Configuration updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L29-R29): Changed the base image from `nginx:stable` to `nginx:stable-alpine` for a smaller image size.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L9-R9): Updated the port mapping to expose the service on port 8080 instead of 80 on localhost.

### Code cleanup:
* [`generate-index.py`](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182L119): Removed unnecessary blank lines and an unused try-except block to improve code readability. [[1]](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182L119) [[2]](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182L172-L173) [[3]](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182L221-L222) [[4]](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182L234) [[5]](diffhunk://#diff-0b0363d569051b27a4b6674d63d2be5ee02f9dd08ac49c618cdd1894d1ade182L245-L247)